### PR TITLE
added jmp2 proxy as live source

### DIFF
--- a/src/PlutoDownload.py
+++ b/src/PlutoDownload.py
@@ -104,6 +104,9 @@ class PlutoRequest:
 	# for URL insertion at runtime
 	PLUTO_SCHEMA = "pluto%3a//"
 
+	# JMP2 proxy URL template (alternative live stream source, resolved at bouquet-build time)
+	JMP2_URL_TEMPLATE = "https://jmp2.uk/plu-%s.m3u8"
+
 	def __init__(self):
 		self.session = requests.Session()
 		self.bootCache = {}
@@ -468,6 +471,7 @@ TSIDS = {cc: "%X" % i for i, cc in enumerate(COUNTRY_NAMES, 1)}
 config.plugins.plutotv = ConfigSubsection()
 config.plugins.plutotv.country = ConfigSelection(default="local", choices=[("local", _("Local"))] + list(COUNTRY_NAMES.items()))
 config.plugins.plutotv.picons = ConfigSelection(default="snp", choices=[("snp", _("service name")), ("srp", _("service reference")), ("", _("None"))])
+config.plugins.plutotv.live_tv_mode = ConfigSelection(default="plutotv", choices=[("plutotv", _("PlutoTV")), ("proxy", _("Proxy (JMP2)"))])
 
 
 def getselectedcountries(skip=0):
@@ -693,7 +697,12 @@ class PlutoDownloadBase():
 
 				ch_sid, ch_hash, ch_name, ch_logourl, _id = self.channelsList[key][self.chitem]
 
-				self.bouquet.append("4097:0:1:%s:%s:FF:CCCC0000:0:0:0:%s:%s" % (ch_sid, self.tsid, plutoRequest.PLUTO_SCHEMA + _id, ch_name))
+				if config.plugins.plutotv.live_tv_mode.value == "proxy":
+					stream_url = (plutoRequest.JMP2_URL_TEMPLATE % _id).replace(":", "%3a")
+				else:
+					stream_url = plutoRequest.PLUTO_SCHEMA + _id
+
+				self.bouquet.append("4097:0:1:%s:%s:FF:CCCC0000:0:0:0:%s:%s" % (ch_sid, self.tsid, stream_url, ch_name))
 				self.chitem += 1
 
 				ref = "4097:0:1:%s:%s:FF:CCCC0000:0:0:0" % (ch_sid, self.tsid)

--- a/src/plugin.py
+++ b/src/plugin.py
@@ -723,6 +723,7 @@ class PlutoSetup(Setup):
 			if n == 1 or getattr(config.plugins.plutotv, "live_tv_country" + str(n - 1)).value:
 				configList.append((_("LiveTV bouquet %s") % n, getattr(config.plugins.plutotv, "live_tv_country" + str(n)), _("Country for which LiveTV bouquet %s will be created.") % n))
 		configList.append(("---",))
+		configList.append((_("Live TV source"), config.plugins.plutotv.live_tv_mode, _("Select the live stream source. PlutoTV uses Pluto's own server with a JWT auth token resolved at playback. Proxy uses the jmp2.uk proxy. Requires bouquet update to take effect.")))
 		configList.append((_("Picon type"), config.plugins.plutotv.picons, _("Using service name picons means they will continue to work even if the service reference changes. Also, they can be shared between channels of the same name that don't have the same service references.")))
 		configList.append((_("Data location"), config.plugins.plutotv.datalocation, _("Used for storing video cover graphics, etc. A hard drive that goes into standby mode or a slow network mount are not good choices.")))
 		self["config"].list = configList


### PR DESCRIPTION
plutotv cdn delivers separate audio and video streams for some channels that gstreamer needs to mux. the problem is that gstreamer has problems to mux the streams during movie to ads transitions which results in playback freezes.
jmp2 proxy delivers the streams already muxed which gstreamer can handle without problems.